### PR TITLE
Adding Darshan profiling - configuration applied after Upgrade

### DIFF
--- a/C_run_bldg_chunk_agg.sh
+++ b/C_run_bldg_chunk_agg.sh
@@ -25,6 +25,10 @@ source /nopt/nrel/apps/env.sh
 module load anaconda3
 conda activate geothermal
 
+### I/O Profiling - Comment out following lines and remove DARSHAN_ENABLE_NONMPI environmental variable if not desired
+ml use /nopt/nrel/apps/software/darshan/modules
+ml darshan
+
 # Limit per-process threading to avoid oversubscription when using many processes
 export OMP_NUM_THREADS=1
 export MKL_NUM_THREADS=1
@@ -33,4 +37,4 @@ export NUMEXPR_NUM_THREADS=1
 export TF_NUM_INTRAOP_THREADS=1
 export TF_NUM_INTEROP_THREADS=1
 
-python $output_dir/inputs/D_process_chunk_agg.py $start_index $end_index $meta_path $upgrade $prefix $output_dir $script_dir $counties_str
+DARSHAN_ENABLE_NONMPI=1 python $output_dir/inputs/D_process_chunk_agg.py $start_index $end_index $meta_path $upgrade $prefix $output_dir $script_dir $counties_str


### PR DESCRIPTION
Enabled I/O profiling for buildstock-weatherreg. Not difficult to add initially, but noticed Python issues in processing I/O due to older version of Darshan. Upgraded system Darshan from 3.4.7 to 3.5.0 and edited configuration settings, works like a charm now 